### PR TITLE
Add tests for permission management and remove deprecated Borealis pe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `staging` needs `staging`; `beta`/`dev` still accept either their own
   value or a `staging` fallback, unchanged), so a config file only needs to
   fill in what the box it's deployed to actually uses.
+- Staff roles and permissions can now be managed interactively from the staff
+  bot: `/staffroles edit [role]` and `/staffperms edit <user>` open a select
+  menu editor (`arcadia/bot/permeditor.go`) with a role picker, a category
+  picker and a multi-select of that category's permissions, preselected to
+  what the role or member currently holds — ticking grants, unticking revokes,
+  and everything outside the open category is carried through untouched.
+  Dangerous permissions are marked ⚠️ and ones the caller cannot manage 🔒.
+  The existing one-at-a-time `grant`/`revoke` subcommands are unchanged and
+  still work; both paths share the same rank check and `perms.CheckPatch`
+  rule, and the editor re-checks both at the moment of the write rather than
+  only when it opened, since a session lives for ten minutes. Every render
+  reloads the target from the database, so two people editing the same role
+  see each other's changes instead of saving a stale picture over them.
+  Alongside the menus are buttons: "Grant all"/"Revoke all" for the open
+  category (which leave permissions the caller cannot manage exactly as they
+  are, so one locked permission doesn't make the button useless), "Pick
+  another role" to switch targets without closing, and "Close". `edit` is
+  registered as the *first* subcommand of both commands, since Discord lists
+  them in registration order and never lets the parent command
+  (`/staffroles` on its own) be invoked at all.
 
 ### Fixed
+
+- Every staff bot slash command appeared twice in every server. The bot
+  registers its commands per guild (`arcadia/bot.SyncCommands`), but the
+  application still carried global registrations of the same commands from an
+  earlier deployment, and Discord lists a global command alongside a guild
+  command of the same name rather than letting the guild copy take its place.
+  `SyncCommands` now finishes by deleting the global registration of any
+  command it registers per guild (`pruneGlobalCommands`), so the duplicates
+  clear themselves on the next sync (startup, or `/register`). Global
+  commands whose names the bot does not register are left alone and only
+  logged as a warning, since they belong to something else sharing the
+  application.
 
 - The `server`/`team` auth types were never registered as OpenAPI security
   schemes (only `User`/`Bot` were, via `docs.AddSecuritySchema` in
@@ -43,6 +75,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ErrNoGateway` unconditionally on a sharded bot regardless of readiness.
   `OnGuildsReady` also fires once per shard, not once globally. Now uses
   `Discord.SetPresenceForShard(ctx, event.ShardID(), ...)` instead.
+
+### Removed
+
+- The `use_borealis` staff permission. Borealis was removed from the platform
+  during the port (`arcadia/CONFORMANCE.md` D11a — the `arcadia.borealis_url`
+  config key, the client and the `Approve` call to it are all long gone), so
+  the permission has gated nothing since and only added a line to
+  `/permissions` and a row to every permission picker. `exp/rewrite/flatperms.sql`
+  now lists the old `borealis.*` in `retired_perm` (dropped on purpose)
+  instead of mapping it onto `use_borealis`, and
+  `exp/rewrite/remove_borealis_perm.sql` strips it from
+  `staff_positions.perms`, `staff_members.perm_overrides` and
+  `staff_disciplinary_types.perm_limits` for databases the old migration
+  already ran against. That cleanup is needed rather than cosmetic: the
+  permission model deliberately keeps names it does not declare, since they
+  may belong to another service, so `use_borealis` would otherwise sit in
+  those columns for good and show up under "Other services".
+
+### Security
+
+- Bot accounts can no longer hold staff permissions at all — not through a
+  staff role, not through a direct grant, and not through `arcadia.owners`
+  (`perms.ErrBotAccount`). Previously nothing stopped one: `StaffResync`
+  walks every member of the staff server and creates a `staff_members` row
+  for anyone holding a position's Discord role, and it never looked at
+  whether that member was a bot, so giving a bot a staff role in Discord
+  handed it that role's permissions — including through the panel session
+  and RPC paths, which only ever asked what the row said. A bot is a token
+  that can be handed to another program, which is exactly what the staff
+  model's accountability assumes cannot happen, and nothing needs it: the
+  staff bot and the panel both act under a staff member's identity, never
+  their own. Enforced on both sides:
+  - Reads: `perms.StaffGrants` carries a `BotAccount` flag, joined in from
+    dovewing's user cache by `LoadStaff` at no extra cost, and `Resolve()`
+    returns nothing and `Rank()` returns `NoRank` when it is set. The panel's
+    session check (`impls.CheckAuthInsecure`), its login
+    (`ops_authorize.go`) and its member view (`impls.GetStaffMember`, whose
+    additory disciplinaries could otherwise add permissions on top of an
+    empty set) all apply the same rule. These paths stay database-only, so
+    they keep working when Discord does not.
+  - Writes: `perms.RejectBotAccount` resolves through dovewing all the way
+    to Discord if the account has never been seen, and fails closed if it
+    cannot tell. `StaffResync` now skips bot members entirely, which also
+    means an existing bot's staff row is cleaned up by the same pass that
+    handles members who left; the panel's `editMember` and the staff bot's
+    `/staffperms grant`/`revoke`/`edit` refuse a bot target outright.
 
 ## [1.0.0] - 2026-08-04
 

--- a/arcadia/bot/framework.go
+++ b/arcadia/bot/framework.go
@@ -380,7 +380,8 @@ func buildCommands() []discord.ApplicationCommandCreate {
 	return cmds
 }
 
-// SyncCommands publishes the slash commands to every staff guild.
+// SyncCommands publishes the slash commands to every staff guild and clears any
+// application-wide copy of them.
 func SyncCommands() error {
 	cmds := buildCommands()
 
@@ -396,6 +397,60 @@ func SyncCommands() error {
 		}
 
 		state.Logger.Info("Registered slash commands", zap.String("guildID", guildID.String()), zap.Int("count", len(cmds)))
+	}
+
+	return pruneGlobalCommands(cmds)
+}
+
+// pruneGlobalCommands deletes the global registration of any command that is
+// also registered per guild.
+//
+// Discord delivers a global command to every guild the application is in and
+// does not let a guild command of the same name stand in for it: both are listed
+// side by side, so a command registered both ways shows up twice in the picker
+// in every server. Everything here goes out per guild (see commandGuilds), which
+// makes a global copy a leftover — from a deployment that registered globally —
+// and the reason the commands were doubled.
+//
+// Global commands whose names this bot does not register are left alone and only
+// logged: they are not ours to delete, and they are not what doubles anything.
+func pruneGlobalCommands(registered []discord.ApplicationCommandCreate) error {
+	appID := dclient.Get().ApplicationID()
+
+	existing, err := dclient.Get().Rest().GetGlobalCommands(appID, false)
+
+	if err != nil {
+		return fmt.Errorf("failed to read the global commands: %w", err)
+	}
+
+	if len(existing) == 0 {
+		return nil
+	}
+
+	ours := make(map[string]struct{}, len(registered))
+
+	for _, cmd := range registered {
+		ours[cmd.CommandName()] = struct{}{}
+	}
+
+	var foreign []string
+
+	for _, cmd := range existing {
+		if _, mine := ours[cmd.Name()]; !mine {
+			foreign = append(foreign, cmd.Name())
+			continue
+		}
+
+		if err := dclient.Get().Rest().DeleteGlobalCommand(appID, cmd.ID()); err != nil {
+			return fmt.Errorf("failed to remove the global copy of /%s: %w", cmd.Name(), err)
+		}
+
+		state.Logger.Info("Removed a duplicate global slash command", zap.String("command", cmd.Name()))
+	}
+
+	if len(foreign) > 0 {
+		state.Logger.Warn("The application has global slash commands this bot does not register; they appear in every server it is in",
+			zap.Strings("commands", foreign))
 	}
 
 	return nil

--- a/arcadia/bot/interactions.go
+++ b/arcadia/bot/interactions.go
@@ -38,6 +38,8 @@ func onComponent(ctx context.Context, e *events.ComponentInteractionCreate) {
 		handleQueueButton(c, e, id, messageID)
 	case id == "fclaim" || id == "remind":
 		handleClaimButton(c, e, id, messageID)
+	case strings.HasPrefix(id, "perm:"):
+		handlePermEditor(c, e, id, messageID)
 	}
 }
 

--- a/arcadia/bot/permeditor.go
+++ b/arcadia/bot/permeditor.go
@@ -1,0 +1,858 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"popplio/arcadia/impls"
+	"popplio/perms"
+	"popplio/state"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+)
+
+// This file is the interactive half of permission management.
+//
+// `/staffroles grant` and `/staffroles revoke` move one permission at a time and
+// need the caller to know its name; the editor here shows what a role actually
+// holds and lets it be changed by ticking boxes in a select menu. The rules are
+// exactly the same either way — rank, and the "you cannot hand out power you do
+// not have" check in perms.CheckPatch — because both paths end in the same write.
+//
+// The editor is deliberately stateless about permissions: every render reloads
+// the target from the database, so two people editing the same role see each
+// other's changes rather than saving a stale picture over them.
+
+const (
+	// permEditorTTL is how long an editor stays live. It is longer than the queue
+	// browser's window because reading a category and deciding on it takes longer
+	// than paging through bots.
+	permEditorTTL = 10 * time.Minute
+
+	// discordSelectLimit is Discord's cap on the options in one select menu.
+	discordSelectLimit = 25
+
+	permSelectRole     = "perm:role"
+	permSelectCategory = "perm:cat"
+	permSelectPerms    = "perm:set"
+	permButtonGrantAll = "perm:all"
+	permButtonClearAll = "perm:none"
+	permButtonBack     = "perm:back"
+	permButtonClose    = "perm:close"
+)
+
+// permSession is one live permission editor, keyed by the message its menus live
+// on. Sessions are author-scoped, like the queue browser's.
+type permSession struct {
+	AuthorID string
+	// RoleID is the staff_positions row being edited, empty until one is picked.
+	RoleID string
+	// UserID is the staff member whose direct grants are being edited. Exactly
+	// one of UserID and RoleID is ever set on a session.
+	UserID string
+	// Category is the permission category currently open in the menu.
+	Category string
+	// Status is the outcome of the last change, shown above the menus.
+	Status    string
+	ExpiresAt time.Time
+}
+
+// editingMember distinguishes the two things an editor can point at.
+func (s *permSession) editingMember() bool {
+	return s.UserID != ""
+}
+
+// permSessions is keyed by the message id the menus live on. It is guarded by
+// sessionsMu, shared with the other component-driven commands.
+var permSessions = map[string]*permSession{}
+
+// errRoleGone is the role being edited having been deleted underneath the
+// session, which the editor recovers from rather than reports.
+var errRoleGone = errors.New("that staff role no longer exists")
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+// runRolesEdit opens the editor on a staff role. The role is optional: without
+// one, the editor opens on its role picker.
+func runRolesEdit(c *Ctx) error {
+	manager, err := requireRoleManager(c)
+
+	if err != nil {
+		return err
+	}
+
+	s := &permSession{
+		AuthorID:  c.Author.ID.String(),
+		ExpiresAt: time.Now().Add(permEditorTTL),
+	}
+
+	if input := strings.TrimSpace(c.Option("role", 0)); input != "" {
+		role, err := lookupStaffRole(c.Context, input)
+
+		if err != nil {
+			return err
+		}
+
+		if err := manager.canEditRole(role); err != nil {
+			return err
+		}
+
+		s.RoleID = role.ID
+	}
+
+	return openPermEditor(c, s)
+}
+
+// runPermsEdit opens the editor on one staff member's direct grants.
+func runPermsEdit(c *Ctx) error {
+	manager, err := loadManager(c)
+
+	if err != nil {
+		return err
+	}
+
+	if !manager.perms.Has(perms.StaffManageStaffMembers) {
+		return fmt.Errorf("You need the %s permission to use this command", perms.Staff.Label(perms.StaffManageStaffMembers))
+	}
+
+	userID := c.Option("user", 0)
+
+	target, err := perms.LoadStaff(c.Context, userID)
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("<@%s> is not a staff member", userID)
+		}
+
+		return err
+	}
+
+	if target.Rank() < manager.rank {
+		return fmt.Errorf("<@%s> outranks you", userID)
+	}
+
+	if err := refuseBotTarget(c.Context, userID, target); err != nil {
+		return err
+	}
+
+	return openPermEditor(c, &permSession{
+		AuthorID:  c.Author.ID.String(),
+		UserID:    userID,
+		ExpiresAt: time.Now().Add(permEditorTTL),
+	})
+}
+
+// openPermEditor posts the editor and remembers it against the message its menus
+// arrived on, which is what the component handler looks the session up by.
+func openPermEditor(c *Ctx, s *permSession) error {
+	msg, err := renderPermEditor(c.Context, s)
+
+	if err != nil {
+		return err
+	}
+
+	messageID, err := c.SendTracked(msg)
+
+	if err != nil {
+		return err
+	}
+
+	sessionsMu.Lock()
+	permSessions[messageID.String()] = s
+	sessionsMu.Unlock()
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Interaction handling
+// ---------------------------------------------------------------------------
+
+// handlePermEditor drives every component on an editor message.
+func handlePermEditor(c *Ctx, e *events.ComponentInteractionCreate, id, messageID string) {
+	// The session is copied out, worked on and written back, so no database
+	// round trip happens while the shared session lock is held.
+	sessionsMu.Lock()
+	stored, ok := permSessions[messageID]
+
+	var s permSession
+
+	if ok {
+		s = *stored
+	}
+
+	sessionsMu.Unlock()
+
+	if !ok {
+		// The bot restarted, or the session was cleaned up: the menus are dead,
+		// so say so rather than leaving the click unanswered.
+		respondEphemeral(e, "This permission editor is no longer active. Run the command again to get a fresh one.")
+		return
+	}
+
+	if s.AuthorID != e.User().ID.String() {
+		respondEphemeral(e, fmt.Sprintf("This permission editor belongs to <@%s>. Run the command yourself to get your own.", s.AuthorID))
+		return
+	}
+
+	if time.Now().After(s.ExpiresAt) {
+		closePermEditor(e, messageID, "This permission editor timed out. Run the command again to carry on.")
+		return
+	}
+
+	if id == permButtonClose {
+		closePermEditor(e, messageID, "Permission editor closed.")
+		return
+	}
+
+	values := selectValues(e)
+
+	switch id {
+	case permSelectRole:
+		if len(values) == 0 {
+			return
+		}
+
+		// The open category is kept when switching roles, which is what makes
+		// "give this to that role too" a two-click job.
+		s.RoleID, s.Status = values[0], ""
+	case permSelectCategory:
+		if len(values) == 0 {
+			return
+		}
+
+		s.Category, s.Status = values[0], ""
+	case permSelectPerms:
+		if s.Category == "" {
+			return
+		}
+
+		s.Status = applyPermSelection(c, &s, values)
+	case permButtonGrantAll, permButtonClearAll:
+		if s.Category == "" {
+			return
+		}
+
+		selection, err := bulkSelection(c.Context, &s, id == permButtonGrantAll)
+
+		if err != nil {
+			s.Status = fmt.Sprintf("Nothing was changed: %s", err)
+			break
+		}
+
+		s.Status = applyPermSelection(c, &s, selection)
+	case permButtonBack:
+		s.RoleID, s.Status = "", ""
+	default:
+		return
+	}
+
+	s.ExpiresAt = time.Now().Add(permEditorTTL)
+
+	msg, err := renderPermEditor(c.Context, &s)
+
+	// A role deleted underneath the session drops the editor back to its picker,
+	// rather than stranding it on something that is not there any more.
+	if errors.Is(err, errRoleGone) {
+		s.RoleID = ""
+		s.Status = "The staff role you were editing has been deleted. Pick another one."
+
+		msg, err = renderPermEditor(c.Context, &s)
+	}
+
+	if err != nil {
+		state.Logger.Error("Failed to render the permission editor", zap.Error(err))
+		respondEphemeral(e, fmt.Sprintf("There was an error running this command: %s", err))
+
+		return
+	}
+
+	sessionsMu.Lock()
+
+	if current, ok := permSessions[messageID]; ok {
+		*current = s
+	}
+
+	sessionsMu.Unlock()
+
+	err = e.UpdateMessage(discord.MessageUpdate{
+		Embeds:     &msg.Embeds,
+		Components: &msg.Components,
+	})
+
+	if err != nil {
+		state.Logger.Error("Failed to update the permission editor", zap.Error(err))
+	}
+}
+
+// closePermEditor ends a session and strips the menus off its message, so a
+// dead editor cannot be clicked again.
+func closePermEditor(e *events.ComponentInteractionCreate, messageID, note string) {
+	sessionsMu.Lock()
+	delete(permSessions, messageID)
+	sessionsMu.Unlock()
+
+	var (
+		content    = note
+		components = []discord.ContainerComponent{}
+		embeds     = []discord.Embed{}
+	)
+
+	err := e.UpdateMessage(discord.MessageUpdate{
+		Content:    &content,
+		Embeds:     &embeds,
+		Components: &components,
+	})
+
+	if err != nil {
+		state.Logger.Error("Failed to close the permission editor", zap.Error(err))
+	}
+}
+
+// applyPermSelection writes the tick boxes of the open category back to the
+// target, and returns the line shown above the menus afterwards.
+//
+// Only the open category is considered: every permission outside it is carried
+// through untouched, so editing one category can never quietly drop another.
+func applyPermSelection(c *Ctx, s *permSession, selected []string) string {
+	manager, err := loadManagerFor(c.Context, s.AuthorID)
+
+	if err != nil {
+		return "Nothing was changed: your own permissions could not be read."
+	}
+
+	target, err := loadPermTarget(c.Context, s)
+
+	if err != nil {
+		return fmt.Sprintf("Nothing was changed: %s", err)
+	}
+
+	if err := permEditAllowed(manager, s, target); err != nil {
+		return fmt.Sprintf("Nothing was changed: %s", err)
+	}
+
+	held := heldMap(target.held)
+
+	chosen := make(map[perms.Perm]bool, len(selected))
+
+	for _, v := range selected {
+		chosen[perms.Perm(v)] = true
+	}
+
+	var granted, revoked []perms.Perm
+
+	for _, d := range perms.Staff.InCategory(s.Category) {
+		switch {
+		case chosen[d.ID] && !held[d.ID]:
+			granted = append(granted, d.ID)
+		case !chosen[d.ID] && held[d.ID]:
+			revoked = append(revoked, d.ID)
+		}
+	}
+
+	if len(granted) == 0 && len(revoked) == 0 {
+		return ""
+	}
+
+	current := perms.Staff.NewSet(target.held...)
+	next := current.With(granted...).Without(revoked...)
+
+	// You cannot hand out, or take away, power you do not have yourself. The
+	// whole selection is refused rather than half-applied, so what the menu shows
+	// afterwards is always what was actually stored.
+	if blocked := perms.Unmanageable(manager.perms, current, next); len(blocked) > 0 {
+		return fmt.Sprintf("Nothing was changed: you do not hold %s yourself.", inlineList(blocked))
+	}
+
+	if err := writePermTarget(c.Context, s, next); err != nil {
+		return fmt.Sprintf("Nothing was changed: %s", err)
+	}
+
+	logPermEdit(c, s, target, granted, revoked)
+
+	return permChangeSummary(s, target, granted, revoked)
+}
+
+// bulkSelection is what the "Grant all" and "Revoke all" buttons submit: the
+// open category with every permission the caller may manage turned on or off.
+//
+// Permissions the caller cannot manage are left exactly as they are, so a
+// category holding one of them still works with one press instead of being
+// refused wholesale.
+func bulkSelection(ctx context.Context, s *permSession, granting bool) ([]string, error) {
+	manager, err := loadManagerFor(ctx, s.AuthorID)
+
+	if err != nil {
+		return nil, errors.New("your own permissions could not be read")
+	}
+
+	target, err := loadPermTarget(ctx, s)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return bulkCategorySelection(s.Category, heldMap(target.held), manager, granting), nil
+}
+
+// bulkCategorySelection is the rule behind those buttons, kept apart from the
+// loading so it can be read and tested on its own.
+func bulkCategorySelection(category string, held map[perms.Perm]bool, manager managerContext, granting bool) []string {
+	var selected []string
+
+	for _, d := range perms.Staff.InCategory(category) {
+		keep := held[d.ID]
+
+		if manager.perms.Has(d.ID) {
+			keep = granting
+		}
+
+		if keep {
+			selected = append(selected, string(d.ID))
+		}
+	}
+
+	return selected
+}
+
+// permEditAllowed re-checks authority at the moment of the write. The command
+// checked it when the editor opened, but a session lives for minutes and the
+// caller's own roles can change inside that window.
+func permEditAllowed(manager managerContext, s *permSession, target permTarget) error {
+	if s.editingMember() {
+		if !manager.perms.Has(perms.StaffManageStaffMembers) {
+			return fmt.Errorf("you need the %s permission", perms.Staff.Label(perms.StaffManageStaffMembers))
+		}
+
+		if target.grants.Rank() < manager.rank {
+			return fmt.Errorf("<@%s> outranks you", s.UserID)
+		}
+
+		// The editor refused to open on a bot; an account that became one since
+		// is refused here too, on the cached flag alone so that the write path
+		// stays a database-only operation.
+		if target.grants.BotAccount {
+			return perms.ErrBotAccount
+		}
+
+		return nil
+	}
+
+	if !manager.perms.Has(perms.StaffManageStaffRoles) {
+		return fmt.Errorf("you need the %s permission", perms.Staff.Label(perms.StaffManageStaffRoles))
+	}
+
+	return manager.canEditRole(target.role)
+}
+
+func writePermTarget(ctx context.Context, s *permSession, next perms.Set) error {
+	if s.editingMember() {
+		tag, err := state.Pool.Exec(ctx, "UPDATE staff_members SET perm_overrides = $1 WHERE user_id = $2", next.Strings(), s.UserID)
+
+		if err != nil {
+			return err
+		}
+
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("<@%s> is no longer a staff member", s.UserID)
+		}
+
+		return nil
+	}
+
+	tag, err := state.Pool.Exec(ctx, "UPDATE staff_positions SET perms = $1 WHERE id = $2", next.Strings(), s.RoleID)
+
+	if err != nil {
+		return err
+	}
+
+	if tag.RowsAffected() == 0 {
+		return errRoleGone
+	}
+
+	return nil
+}
+
+func permChangeSummary(s *permSession, target permTarget, granted, revoked []perms.Perm) string {
+	var parts []string
+
+	if len(granted) > 0 {
+		parts = append(parts, "granted "+inlineList(granted))
+	}
+
+	if len(revoked) > 0 {
+		parts = append(parts, "revoked "+inlineList(revoked))
+	}
+
+	summary := "You " + strings.Join(parts, " and ")
+
+	if s.editingMember() {
+		return fmt.Sprintf("%s for <@%s> directly.", summary, s.UserID)
+	}
+
+	return fmt.Sprintf("%s. This applies immediately to the %d member(s) with %s.", summary, target.holders, target.role.Mention())
+}
+
+func logPermEdit(c *Ctx, s *permSession, target permTarget, granted, revoked []perms.Perm) {
+	var parts []string
+
+	if len(granted) > 0 {
+		parts = append(parts, "Granted "+inlineList(granted))
+	}
+
+	if len(revoked) > 0 {
+		parts = append(parts, "revoked "+inlineList(revoked))
+	}
+
+	change := strings.Join(parts, " and ")
+
+	if s.editingMember() {
+		logRoleChange(c, "Staff member permissions changed",
+			fmt.Sprintf("%s for <@%s> directly.", change, s.UserID))
+
+		return
+	}
+
+	logRoleChange(c, "Staff role permissions changed",
+		fmt.Sprintf("%s on **%s** (<@&%s>).", change, target.role.Name, target.role.RoleID))
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+// permTarget is what a session points at, loaded fresh on every render so the
+// menus never show a stale picture of the permissions they are editing.
+type permTarget struct {
+	// roles is every staff role, for the picker; nil when editing a member.
+	roles []staffRole
+	// role is the staff role being edited, valid only when picked is set.
+	role   staffRole
+	picked bool
+	// grants is the member's own grants when editing a member.
+	grants perms.StaffGrants
+	// held is exactly what is stored on the target — a role's permissions or a
+	// member's direct grants — and never a member's effective set.
+	held []perms.Perm
+	// holders is how many people a change to this target reaches.
+	holders int
+}
+
+func loadPermTarget(ctx context.Context, s *permSession) (permTarget, error) {
+	if s.editingMember() {
+		grants, err := perms.LoadStaff(ctx, s.UserID)
+
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return permTarget{}, fmt.Errorf("<@%s> is not a staff member", s.UserID)
+			}
+
+			return permTarget{}, err
+		}
+
+		return permTarget{grants: grants, held: grants.Extras, holders: 1}, nil
+	}
+
+	roles, err := listStaffRoles(ctx)
+
+	if err != nil {
+		return permTarget{}, err
+	}
+
+	t := permTarget{roles: roles}
+
+	if s.RoleID == "" {
+		return t, nil
+	}
+
+	for _, r := range roles {
+		if r.ID == s.RoleID {
+			t.role, t.picked, t.held = r, true, r.Perms
+			break
+		}
+	}
+
+	if !t.picked {
+		return permTarget{}, errRoleGone
+	}
+
+	counts, err := roleHolderCounts(ctx)
+
+	if err != nil {
+		return permTarget{}, err
+	}
+
+	t.holders = counts[t.role.ID]
+
+	return t, nil
+}
+
+// renderPermEditor draws the editor for what is currently stored.
+func renderPermEditor(ctx context.Context, s *permSession) (discord.MessageCreate, error) {
+	manager, err := loadManagerFor(ctx, s.AuthorID)
+
+	if err != nil {
+		return discord.MessageCreate{}, err
+	}
+
+	target, err := loadPermTarget(ctx, s)
+
+	if err != nil {
+		return discord.MessageCreate{}, err
+	}
+
+	held := heldMap(target.held)
+	editing := target.picked || s.editingMember()
+
+	embed := discord.Embed{Color: impls.ColourGreen}
+
+	switch {
+	case s.editingMember():
+		embed.Title = "Editing permissions granted directly"
+		embed.Description = fmt.Sprintf("<@%s>", s.UserID)
+	case target.picked:
+		embed.Title = "Editing staff role: " + target.role.Name
+		embed.Description = fmt.Sprintf("%s · rank #%d · %d member(s)", target.role.Mention(), target.role.Index, target.holders)
+	default:
+		embed.Title = "Editing staff roles"
+		embed.Description = "Pick the staff role to edit. Only roles below your own rank are listed."
+	}
+
+	if s.Status != "" {
+		embed.Description += "\n\n" + s.Status
+	}
+
+	if editing {
+		if s.editingMember() {
+			embed.Fields = append(embed.Fields, discord.EmbedField{
+				Name:   "Roles",
+				Value:  roleSummary(target.grants),
+				Inline: impls.InlineFalse(),
+			})
+		}
+
+		embed.Fields = append(embed.Fields, permissionFields(perms.Staff.NewSet(target.held...))...)
+
+		embed.Footer = &discord.EmbedFooter{
+			Text: "Tick to grant, untick to revoke. ⚠️ is a dangerous permission, 🔒 one you cannot manage.",
+		}
+	}
+
+	var rows []discord.ContainerComponent
+
+	if !s.editingMember() {
+		if row, ok := roleSelectRow(target.roles, s, manager); ok {
+			rows = append(rows, row)
+		} else if !target.picked {
+			embed.Description = "There is no staff role below your own rank for you to edit."
+		}
+	}
+
+	if editing {
+		rows = append(rows, discord.NewActionRow(categorySelect(s, held)))
+
+		if menu, ok := permissionSelect(s, held, manager); ok {
+			rows = append(rows, discord.NewActionRow(menu))
+		}
+	}
+
+	rows = append(rows, discord.NewActionRow(editorButtons(s, editing)...))
+
+	return discord.MessageCreate{Embeds: []discord.Embed{embed}, Components: rows}, nil
+}
+
+// editorButtons are the actions that are a press rather than a selection.
+//
+// The bulk ones only appear with a category open, since that is what they act
+// on; offering them before then would be offering to do nothing.
+func editorButtons(s *permSession, editing bool) []discord.InteractiveComponent {
+	var buttons []discord.InteractiveComponent
+
+	if editing && s.Category != "" {
+		buttons = append(buttons,
+			discord.NewSuccessButton("Grant all", permButtonGrantAll),
+			discord.NewDangerButton("Revoke all", permButtonClearAll),
+		)
+	}
+
+	// Switching roles without closing the editor is what makes copying a
+	// category across two roles a handful of clicks.
+	if !s.editingMember() && s.RoleID != "" {
+		buttons = append(buttons, discord.NewSecondaryButton("Pick another role", permButtonBack))
+	}
+
+	return append(buttons, discord.NewSecondaryButton("Close", permButtonClose))
+}
+
+// roleSelectRow lists the roles the caller may edit. Roles at or above their own
+// rank are left out rather than shown and refused on click.
+func roleSelectRow(roles []staffRole, s *permSession, manager managerContext) (discord.ContainerComponent, bool) {
+	options := make([]discord.StringSelectMenuOption, 0, len(roles))
+
+	for _, r := range roles {
+		if manager.canEditRole(r) != nil {
+			continue
+		}
+
+		if len(options) == discordSelectLimit {
+			break
+		}
+
+		options = append(options, discord.NewStringSelectMenuOption(
+			truncate(fmt.Sprintf("#%d · %s", r.Index, r.Name), 100), r.ID).
+			WithDescription(fmt.Sprintf("%d permission(s)", len(r.Perms))).
+			WithDefault(r.ID == s.RoleID))
+	}
+
+	if len(options) == 0 {
+		return nil, false
+	}
+
+	return discord.NewActionRow(discord.NewStringSelectMenu(permSelectRole, "Staff role to edit", options...)), true
+}
+
+// categorySelect is the category picker, labelled with how much of each category
+// the target already holds so the interesting ones stand out.
+func categorySelect(s *permSession, held map[perms.Perm]bool) discord.StringSelectMenuComponent {
+	categories := perms.Staff.Categories()
+
+	if len(categories) > discordSelectLimit {
+		categories = categories[:discordSelectLimit]
+	}
+
+	options := make([]discord.StringSelectMenuOption, 0, len(categories))
+
+	for _, category := range categories {
+		defs := perms.Staff.InCategory(category)
+		granted := 0
+
+		for _, d := range defs {
+			if held[d.ID] {
+				granted++
+			}
+		}
+
+		options = append(options, discord.NewStringSelectMenuOption(truncate(category, 100), category).
+			WithDescription(fmt.Sprintf("%d of %d granted", granted, len(defs))).
+			WithDefault(category == s.Category))
+	}
+
+	return discord.NewStringSelectMenu(permSelectCategory, "Permission category", options...)
+}
+
+// permissionSelect is the editor proper: one multi-select of the open category,
+// with the permissions the target already holds preselected, so submitting it
+// describes the state wanted rather than a change to make.
+func permissionSelect(s *permSession, held map[perms.Perm]bool, manager managerContext) (discord.StringSelectMenuComponent, bool) {
+	if s.Category == "" {
+		return discord.StringSelectMenuComponent{}, false
+	}
+
+	defs := perms.Staff.InCategory(s.Category)
+
+	if len(defs) > discordSelectLimit {
+		defs = defs[:discordSelectLimit]
+	}
+
+	if len(defs) == 0 {
+		return discord.StringSelectMenuComponent{}, false
+	}
+
+	options := make([]discord.StringSelectMenuOption, 0, len(defs))
+
+	for _, d := range defs {
+		label := d.Name
+
+		if d.Dangerous {
+			label = "⚠️ " + label
+		}
+
+		// A permission the caller does not hold themselves cannot be granted or
+		// revoked by them, so it is marked here instead of only failing on submit.
+		if !manager.perms.Has(d.ID) {
+			label = "🔒 " + label
+		}
+
+		options = append(options, discord.NewStringSelectMenuOption(truncate(label, 100), string(d.ID)).
+			WithDescription(truncate(d.Description, 100)).
+			WithDefault(held[d.ID]))
+	}
+
+	menu := discord.NewStringSelectMenu(permSelectPerms, truncate(s.Category+" permissions", 100), options...).
+		WithMinValues(0).
+		WithMaxValues(len(options))
+
+	return menu, true
+}
+
+func roleSummary(grants perms.StaffGrants) string {
+	if len(grants.Roles) == 0 {
+		return "None"
+	}
+
+	names := make([]string, 0, len(grants.Roles))
+
+	for _, r := range grants.Roles {
+		names = append(names, fmt.Sprintf("#%d %s", r.Index, r.Name))
+	}
+
+	return strings.Join(names, "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// heldMap reads a stored permission list exactly, without the super permission's
+// implication: an editor must show what would be written back, not what the
+// holder can do.
+func heldMap(list []perms.Perm) map[perms.Perm]bool {
+	out := make(map[perms.Perm]bool, len(list))
+
+	for _, p := range list {
+		out[p] = true
+	}
+
+	return out
+}
+
+func inlineList(list []perms.Perm) string {
+	out := make([]string, 0, len(list))
+
+	for _, p := range list {
+		out = append(out, "``"+string(p)+"``")
+	}
+
+	return strings.Join(out, ", ")
+}
+
+func selectValues(e *events.ComponentInteractionCreate) []string {
+	data, ok := e.Data.(discord.StringSelectMenuInteractionData)
+
+	if !ok {
+		return nil
+	}
+
+	return data.Values
+}
+
+// respondEphemeral answers an interaction with a message only its clicker sees,
+// which is how a refusal reaches them without editing the shared message.
+func respondEphemeral(e *events.ComponentInteractionCreate, content string) {
+	err := e.CreateMessage(discord.MessageCreate{
+		Content: content,
+		Flags:   discord.MessageFlagEphemeral,
+	})
+
+	if err != nil {
+		state.Logger.Error("Failed to answer a permission editor interaction", zap.Error(err))
+	}
+}

--- a/arcadia/bot/permeditor_test.go
+++ b/arcadia/bot/permeditor_test.go
@@ -1,0 +1,323 @@
+package bot
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"popplio/perms"
+
+	"github.com/disgoorg/disgo/discord"
+)
+
+// The menus have to fit inside Discord's caps, and the catalogue is free to grow
+// past them: a category with 26 permissions would otherwise be rejected outright
+// at render time, in production, with no test having noticed.
+func TestPermissionSelectFitsDiscordLimits(t *testing.T) {
+	manager := managerContext{perms: perms.Staff.NewSet(perms.StaffAdministrator)}
+
+	for _, category := range perms.Staff.Categories() {
+		s := &permSession{Category: category}
+
+		menu, ok := permissionSelect(s, map[perms.Perm]bool{}, manager)
+
+		if !ok {
+			t.Fatalf("category %q rendered no menu", category)
+		}
+
+		if len(menu.Options) > discordSelectLimit {
+			t.Errorf("category %q has %d options, over Discord's cap", category, len(menu.Options))
+		}
+
+		if len(menu.Placeholder) > 100 {
+			t.Errorf("category %q has a %d character placeholder", category, len(menu.Placeholder))
+		}
+
+		for _, opt := range menu.Options {
+			if len(opt.Label) > 100 {
+				t.Errorf("%q has a %d character label", opt.Value, len(opt.Label))
+			}
+
+			if len(opt.Description) > 100 {
+				t.Errorf("%q has a %d character description", opt.Value, len(opt.Description))
+			}
+		}
+	}
+
+	if len(perms.Staff.Categories()) > discordSelectLimit {
+		t.Errorf("%d categories will not fit in one select menu", len(perms.Staff.Categories()))
+	}
+}
+
+// What is already held must come back preselected, or submitting the menu
+// unchanged would read as "revoke everything in this category".
+func TestPermissionSelectPreselectsHeld(t *testing.T) {
+	def, _ := perms.Staff.Lookup(perms.StaffReviewBots)
+	s := &permSession{Category: def.Category}
+
+	held := map[perms.Perm]bool{perms.StaffReviewBots: true}
+
+	menu, ok := permissionSelect(s, held, managerContext{perms: perms.Staff.NewSet(perms.StaffAdministrator)})
+
+	if !ok {
+		t.Fatal("the review category rendered no menu")
+	}
+
+	var found bool
+
+	for _, opt := range menu.Options {
+		if opt.Value != string(perms.StaffReviewBots) {
+			continue
+		}
+
+		found = true
+
+		if !opt.Default {
+			t.Error("a held permission should be preselected")
+		}
+	}
+
+	if !found {
+		t.Fatalf("review_bots is missing from the %q menu", def.Category)
+	}
+
+	// Nothing may be selected, and everything may be, so a category can be
+	// emptied or filled in one submission.
+	if menu.MinValues == nil || *menu.MinValues != 0 {
+		t.Error("the menu must allow an empty selection, which is how a category is cleared")
+	}
+
+	if menu.MaxValues != len(menu.Options) {
+		t.Errorf("the menu allows %d of %d options to be selected", menu.MaxValues, len(menu.Options))
+	}
+}
+
+// A permission the caller cannot manage is shown, marked, rather than hidden:
+// they still need to see what a role holds.
+func TestPermissionSelectMarksUnmanageable(t *testing.T) {
+	def, _ := perms.Staff.Lookup(perms.StaffForceRemoveBots)
+
+	// A manager who can review bots but not force remove them.
+	manager := managerContext{perms: perms.Staff.NewSet(perms.StaffReviewBots)}
+
+	menu, ok := permissionSelect(&permSession{Category: def.Category}, map[perms.Perm]bool{}, manager)
+
+	if !ok {
+		t.Fatal("the category rendered no menu")
+	}
+
+	for _, opt := range menu.Options {
+		switch opt.Value {
+		case string(perms.StaffForceRemoveBots):
+			if !strings.Contains(opt.Label, "🔒") {
+				t.Errorf("an unmanageable permission should be marked, got %q", opt.Label)
+			}
+
+			// It is dangerous as well, and both marks belong on it.
+			if !strings.Contains(opt.Label, "⚠️") {
+				t.Errorf("a dangerous permission should be marked, got %q", opt.Label)
+			}
+		case string(perms.StaffReviewBots):
+			if strings.Contains(opt.Label, "🔒") {
+				t.Errorf("a manageable permission should not be marked, got %q", opt.Label)
+			}
+		}
+	}
+}
+
+// The role picker offers only what the caller may actually edit, so a click can
+// never be refused for a reason the menu already knew about.
+func TestRoleSelectRowHidesSeniorRoles(t *testing.T) {
+	roles := []staffRole{
+		{ID: "a", Name: "Owner", Index: 1},
+		{ID: "b", Name: "Head Admin", Index: 3},
+		{ID: "c", Name: "Moderator", Index: 5},
+	}
+
+	row, ok := roleSelectRow(roles, &permSession{RoleID: "c"}, managerContext{rank: 3})
+
+	if !ok {
+		t.Fatal("a manager with a junior role below them should get a picker")
+	}
+
+	menu, valid := row.(discord.ActionRowComponent)[0].(discord.StringSelectMenuComponent)
+
+	if !valid {
+		t.Fatal("the role picker is not a string select menu")
+	}
+
+	if len(menu.Options) != 1 || menu.Options[0].Value != "c" {
+		t.Fatalf("only the junior role should be offered, got %+v", menu.Options)
+	}
+
+	if !menu.Options[0].Default {
+		t.Error("the role being edited should be preselected")
+	}
+
+	// A manager at the bottom of the hierarchy has nothing to pick.
+	if _, ok := roleSelectRow(roles, &permSession{}, managerContext{rank: perms.NoRank}); ok {
+		t.Error("a manager who outranks nobody should get no picker")
+	}
+}
+
+// "Grant all" and "Revoke all" must never build a selection that the write path
+// will refuse: they leave permissions the caller cannot manage exactly as they
+// are, so one locked permission does not make the button useless.
+func TestBulkCategorySelectionLeavesUnmanageableAlone(t *testing.T) {
+	def, _ := perms.Staff.Lookup(perms.StaffReviewBots)
+	category := def.Category
+
+	// Can review, cannot force remove.
+	manager := managerContext{perms: perms.Staff.NewSet(perms.StaffReviewBots, perms.StaffCertifyBots, perms.StaffTransferBots)}
+
+	held := map[perms.Perm]bool{perms.StaffForceRemoveBots: true}
+
+	granted := bulkCategorySelection(category, held, manager, true)
+
+	if !slices.Contains(granted, string(perms.StaffReviewBots)) {
+		t.Error("grant all should turn on a permission the caller manages")
+	}
+
+	if !slices.Contains(granted, string(perms.StaffForceRemoveBots)) {
+		t.Error("grant all must keep an unmanageable permission that is already held, or the write is refused")
+	}
+
+	revoked := bulkCategorySelection(category, held, manager, false)
+
+	if slices.Contains(revoked, string(perms.StaffReviewBots)) {
+		t.Error("revoke all should turn off a permission the caller manages")
+	}
+
+	if !slices.Contains(revoked, string(perms.StaffForceRemoveBots)) {
+		t.Error("revoke all must leave an unmanageable permission held, not try to take it")
+	}
+
+	// A caller who manages nothing in the category changes nothing with either
+	// button, rather than submitting a change that will bounce.
+	none := managerContext{perms: perms.Staff.NewSet()}
+
+	if got := bulkCategorySelection(category, held, none, true); len(got) != 1 || got[0] != string(perms.StaffForceRemoveBots) {
+		t.Errorf("grant all with no authority should be a no-op, got %v", got)
+	}
+}
+
+// The buttons are the other half of "interactive", and which ones are offered
+// depends on where the editor is.
+func TestEditorButtons(t *testing.T) {
+	ids := func(components []discord.InteractiveComponent) []string {
+		out := make([]string, 0, len(components))
+
+		for _, c := range components {
+			out = append(out, c.ID())
+		}
+
+		return out
+	}
+
+	// On the role picker: nothing to act on yet.
+	got := ids(editorButtons(&permSession{}, false))
+
+	if len(got) != 1 || got[0] != permButtonClose {
+		t.Errorf("the picker should offer only Close, got %v", got)
+	}
+
+	// A role open, no category yet: no bulk actions, but a way back.
+	got = ids(editorButtons(&permSession{RoleID: "abc"}, true))
+
+	if slices.Contains(got, permButtonGrantAll) {
+		t.Errorf("grant all needs a category open, got %v", got)
+	}
+
+	if !slices.Contains(got, permButtonBack) {
+		t.Errorf("a role being edited should offer a way back to the picker, got %v", got)
+	}
+
+	// A category open: everything.
+	got = ids(editorButtons(&permSession{RoleID: "abc", Category: "Bot Reviews"}, true))
+
+	for _, want := range []string{permButtonGrantAll, permButtonClearAll, permButtonBack, permButtonClose} {
+		if !slices.Contains(got, want) {
+			t.Errorf("%q is missing from %v", want, got)
+		}
+	}
+
+	// Discord caps an action row at five components.
+	if len(got) > 5 {
+		t.Errorf("%d buttons will not fit in one action row", len(got))
+	}
+
+	// A member editor has no role picker to go back to.
+	got = ids(editorButtons(&permSession{UserID: "42", Category: "Bot Reviews"}, true))
+
+	if slices.Contains(got, permButtonBack) {
+		t.Errorf("a member editor should not offer the role picker, got %v", got)
+	}
+}
+
+// The category counts are what tell someone where to look before they open
+// anything.
+func TestCategorySelectCountsHeld(t *testing.T) {
+	def, _ := perms.Staff.Lookup(perms.StaffReviewBots)
+
+	menu := categorySelect(&permSession{Category: def.Category}, map[perms.Perm]bool{perms.StaffReviewBots: true})
+
+	var found bool
+
+	for _, opt := range menu.Options {
+		if opt.Value != def.Category {
+			continue
+		}
+
+		found = true
+
+		want := fmt.Sprintf("1 of %d granted", len(perms.Staff.InCategory(def.Category)))
+
+		if opt.Description != want {
+			t.Errorf("description = %q, want %q", opt.Description, want)
+		}
+
+		if !opt.Default {
+			t.Error("the open category should be preselected")
+		}
+	}
+
+	if !found {
+		t.Fatalf("category %q is missing from the picker", def.Category)
+	}
+}
+
+// heldMap reads the stored list exactly. Administrator implies everything for an
+// access check, but an editor that ticked every box for an administrator role
+// would write those permissions out on the next submission.
+func TestHeldMapIsExact(t *testing.T) {
+	held := heldMap([]perms.Perm{perms.StaffAdministrator})
+
+	if !held[perms.StaffAdministrator] {
+		t.Error("administrator should be held")
+	}
+
+	if held[perms.StaffReviewBots] {
+		t.Error("administrator implies review_bots but does not store it, so the box must be unticked")
+	}
+}
+
+func TestPermChangeSummary(t *testing.T) {
+	role := permTarget{role: staffRole{Name: "Moderator", RoleID: "123"}, holders: 4}
+
+	got := permChangeSummary(&permSession{RoleID: "x"}, role,
+		[]perms.Perm{perms.StaffReviewBots}, []perms.Perm{perms.StaffCertifyBots})
+
+	for _, want := range []string{"granted ``review_bots``", "revoked ``certify_bots``", "4 member(s)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary %q should contain %q", got, want)
+		}
+	}
+
+	// A member's change reaches only them, so it must not claim a member count.
+	got = permChangeSummary(&permSession{UserID: "42"}, permTarget{holders: 1}, []perms.Perm{perms.StaffViewPanel}, nil)
+
+	if !strings.Contains(got, "<@42>") || strings.Contains(got, "member(s) with") {
+		t.Errorf("a member summary should name the member and nothing else, got %q", got)
+	}
+}

--- a/arcadia/bot/staffroles.go
+++ b/arcadia/bot/staffroles.go
@@ -65,12 +65,28 @@ func cmdStaffRoles() *Command {
 		Required:    true,
 	}
 
+	// The editor can open on its own role picker, so naming a role is optional
+	// there and required everywhere else.
+	optionalRoleOption := roleOption
+	optionalRoleOption.Required = false
+
 	return &Command{
 		Name:        "staffroles",
 		Category:    "Staff Management",
 		Description: "See and manage staff roles and the permissions attached to them",
 		Checks:      []Check{staffServer, isStaff},
+		// Discord lists subcommands in registration order and never lets the
+		// parent command be run on its own, so the interactive one goes first:
+		// it is what most of this command is for.
 		Subcommands: []*Command{
+			{
+				Name:        "edit",
+				Category:    "Staff Management",
+				Description: "Grant and revoke a role's permissions with menus and buttons",
+				Checks:      []Check{staffServer, isStaff},
+				Options:     []discord.ApplicationCommandOption{optionalRoleOption},
+				Run:         runRolesEdit,
+			},
 			{
 				Name:        "list",
 				Category:    "Staff Management",
@@ -141,7 +157,7 @@ func cmdStaffRoles() *Command {
 			},
 		},
 		Run: func(c *Ctx) error {
-			return c.Say("Use one of: ``list``, ``show``, ``create``, ``grant``, ``revoke``, ``rename``, ``delete``, ``sync``.")
+			return c.Say("Use one of: ``list``, ``show``, ``edit``, ``create``, ``grant``, ``revoke``, ``rename``, ``delete``, ``sync``. ``edit`` is the interactive one.")
 		},
 	}
 }
@@ -498,7 +514,16 @@ func cmdStaffPerms() *Command {
 		Category:    "Staff Management",
 		Description: "See and manage what a staff member can do",
 		Checks:      []Check{staffServer, isStaff},
+		// The interactive one goes first here too; see cmdStaffRoles.
 		Subcommands: []*Command{
+			{
+				Name:        "edit",
+				Category:    "Staff Management",
+				Description: "Grant and revoke a member's own permissions with menus and buttons",
+				Checks:      []Check{staffServer, isStaff},
+				Options:     []discord.ApplicationCommandOption{userOption},
+				Run:         runPermsEdit,
+			},
 			{
 				Name:        "show",
 				Category:    "Staff Management",
@@ -535,7 +560,7 @@ func cmdStaffPerms() *Command {
 			},
 		},
 		Run: func(c *Ctx) error {
-			return c.Say("Use one of: ``show``, ``check``, ``grant``, ``revoke``.")
+			return c.Say("Use one of: ``show``, ``check``, ``edit``, ``grant``, ``revoke``. ``edit`` is the interactive one.")
 		},
 	}
 }
@@ -685,6 +710,10 @@ func editMemberExtras(c *Ctx, granting bool) error {
 		return fmt.Errorf("<@%s> outranks you", userID)
 	}
 
+	if err := refuseBotTarget(c.Context, userID, target); err != nil {
+		return err
+	}
+
 	perm, err := resolvePermission(c.Option("permission", 1))
 
 	if err != nil {
@@ -802,13 +831,37 @@ type managerContext struct {
 }
 
 func loadManager(c *Ctx) (managerContext, error) {
-	grants, err := perms.LoadStaff(c.Context, c.Author.ID.String())
+	return loadManagerFor(c.Context, c.Author.ID.String())
+}
+
+// loadManagerFor is loadManager for a caller that is not the one in hand, which
+// is what the permission editor has: its session outlives the invocation that
+// opened it and only remembers who owns it.
+func loadManagerFor(ctx context.Context, userID string) (managerContext, error) {
+	grants, err := perms.LoadStaff(ctx, userID)
 
 	if err != nil {
 		return managerContext{}, err
 	}
 
 	return managerContext{perms: grants.Resolve(), rank: grants.Rank()}, nil
+}
+
+// refuseBotTarget stops a permission being granted to a bot account.
+//
+// The cached flag on the grants answers it for free when dovewing has seen the
+// account before; otherwise the authoritative check runs, which is affordable
+// here because granting a permission is a rare, deliberate act.
+func refuseBotTarget(ctx context.Context, userID string, target perms.StaffGrants) error {
+	if target.BotAccount {
+		return fmt.Errorf("<@%s> is a bot: %w", userID, perms.ErrBotAccount)
+	}
+
+	if err := perms.RejectBotAccount(ctx, userID); err != nil {
+		return fmt.Errorf("<@%s>: %w", userID, err)
+	}
+
+	return nil
 }
 
 // requireRoleManager loads the caller and checks they may manage roles at all.

--- a/arcadia/bot/staffroles_test.go
+++ b/arcadia/bot/staffroles_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"popplio/perms"
+
+	"github.com/disgoorg/disgo/discord"
 )
 
 func TestResolvePermission(t *testing.T) {
@@ -174,6 +176,85 @@ func TestStaffCommandsRegisterCleanly(t *testing.T) {
 			if len(sub.Description) > 100 {
 				t.Errorf("%s %s has a %d character description", cmd.Name, sub.Name, len(sub.Description))
 			}
+		}
+	}
+}
+
+// Discord rejects a whole command whose options put a required one after an
+// optional one, and a rejected command is simply missing from the picker with
+// nothing to show for it but a line in the startup log. The registration payload
+// is checked here so that a bad option order fails the build instead.
+func TestCommandOptionsRegisterInAValidOrder(t *testing.T) {
+	registry = map[string]*Command{}
+	ordered = nil
+
+	registerCommands()
+
+	var check func(path string, options []discord.ApplicationCommandOption)
+
+	check = func(path string, options []discord.ApplicationCommandOption) {
+		optionalSeen := ""
+
+		for _, opt := range options {
+			if sub, ok := opt.(discord.ApplicationCommandOptionSubCommand); ok {
+				check(path+" "+sub.Name, sub.Options)
+				continue
+			}
+
+			required := false
+
+			switch o := opt.(type) {
+			case discord.ApplicationCommandOptionString:
+				required = o.Required
+			case discord.ApplicationCommandOptionUser:
+				required = o.Required
+			case discord.ApplicationCommandOptionRole:
+				required = o.Required
+			case discord.ApplicationCommandOptionInt:
+				required = o.Required
+			case discord.ApplicationCommandOptionBool:
+				required = o.Required
+			}
+
+			if required && optionalSeen != "" {
+				t.Errorf("%s: required option %q comes after optional %q, which Discord rejects",
+					path, opt.OptionName(), optionalSeen)
+			}
+
+			if !required {
+				optionalSeen = opt.OptionName()
+			}
+		}
+	}
+
+	for _, cmd := range buildCommands() {
+		slash, ok := cmd.(discord.SlashCommandCreate)
+
+		if !ok {
+			continue
+		}
+
+		check("/"+slash.Name, slash.Options)
+	}
+}
+
+// The interactive editor is what these commands are mostly for, and Discord
+// lists subcommands in the order they are registered.
+func TestEditIsTheFirstSubcommand(t *testing.T) {
+	registry = map[string]*Command{}
+	ordered = nil
+
+	registerCommands()
+
+	for _, name := range []string{"staffroles", "staffperms"} {
+		cmd, ok := registry[name]
+
+		if !ok {
+			t.Fatalf("%s is not registered", name)
+		}
+
+		if len(cmd.Subcommands) == 0 || cmd.Subcommands[0].Name != "edit" {
+			t.Errorf("/%s should offer edit first, got %q", name, cmd.Subcommands[0].Name)
 		}
 	}
 }

--- a/arcadia/impls/auth.go
+++ b/arcadia/impls/auth.go
@@ -70,9 +70,18 @@ func CheckAuthInsecure(ctx context.Context, token string) (types.AuthData, error
 		return types.AuthData{}, err
 	}
 
-	var positions []pgtype.UUID
+	var (
+		positions []pgtype.UUID
+		isBot     bool
+	)
 
-	err = state.Pool.QueryRow(ctx, "SELECT positions FROM staff_members WHERE user_id = $1", userID).Scan(&positions)
+	// The bot flag rides along on this query rather than costing a round trip of
+	// its own, since it is read on every authenticated request.
+	err = state.Pool.QueryRow(ctx, `
+		SELECT sm.positions, COALESCE(iuc.bot, false)
+		FROM staff_members sm
+		LEFT JOIN internal_user_cache__discord iuc ON iuc.id = sm.user_id
+		WHERE sm.user_id = $1`, userID).Scan(&positions, &isBot)
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -83,6 +92,12 @@ func CheckAuthInsecure(ctx context.Context, token string) (types.AuthData, error
 	}
 
 	if len(positions) == 0 {
+		return types.AuthData{}, ErrIdentityExpired
+	}
+
+	// A bot holds no staff permissions, so a session on one is not a session at
+	// all — however it came to exist.
+	if isBot {
 		return types.AuthData{}, ErrIdentityExpired
 	}
 
@@ -253,10 +268,20 @@ func GetStaffMember(ctx context.Context, userID string) (types.StaffMember, erro
 		return types.StaffMember{}, fmt.Errorf("Error while getting positions of user %s: %s", userID, err)
 	}
 
+	// The dovewing user is fetched before the permissions are resolved rather
+	// than alongside the response, because whether this is a bot decides what
+	// resolving can produce at all.
+	user, err := GetPlatformUser(ctx, userID)
+
+	if err != nil {
+		return types.StaffMember{}, err
+	}
+
 	grants := perms.StaffGrants{
 		Roles:       make([]perms.Role, 0, len(positionRows)),
 		Extras:      perms.ParseStrings(permOverrides),
 		ConfigOwner: perms.IsConfigOwner(userID),
+		BotAccount:  user.Bot,
 	}
 
 	positions := make([]types.StaffPosition, 0, len(positionRows))
@@ -291,12 +316,6 @@ func GetStaffMember(ctx context.Context, userID string) (types.StaffMember, erro
 
 	resolved := resolveWithDisciplinaries(grants, disciplinaries)
 
-	user, err := GetPlatformUser(ctx, userID)
-
-	if err != nil {
-		return types.StaffMember{}, err
-	}
-
 	return types.StaffMember{
 		UserID:         userID,
 		User:           user,
@@ -322,6 +341,12 @@ func GetStaffMember(ctx context.Context, userID string) (types.StaffMember, erro
 // That is what makes it a punishment — a suspended reviewer keeps nothing but
 // the limits their disciplinary spells out.
 func resolveWithDisciplinaries(grants perms.StaffGrants, disciplinaries []types.StaffDisciplinary) perms.Set {
+	// A bot holds nothing, and an additory disciplinary adds permissions on top
+	// of what is resolved — so a bot is answered before one can be applied.
+	if grants.BotAccount {
+		return perms.Staff.NewSet()
+	}
+
 	// An instance owner cannot be disciplined out of their own instance.
 	if len(disciplinaries) == 0 || grants.ConfigOwner {
 		return grants.Resolve()

--- a/arcadia/panel/ops_authorize.go
+++ b/arcadia/panel/ops_authorize.go
@@ -141,9 +141,16 @@ func (s *Server) authCreateSession(ctx context.Context, action *types.AuthCreate
 		return response{}, newError(err)
 	}
 
-	var positions []string
+	var (
+		positions []string
+		isBot     bool
+	)
 
-	err = state.Pool.QueryRow(ctx, "SELECT positions FROM staff_members WHERE user_id = $1", user.ID).Scan(&positions)
+	err = state.Pool.QueryRow(ctx, `
+		SELECT sm.positions, COALESCE(iuc.bot, false)
+		FROM staff_members sm
+		LEFT JOIN internal_user_cache__discord iuc ON iuc.id = sm.user_id
+		WHERE sm.user_id = $1`, user.ID).Scan(&positions, &isBot)
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -155,6 +162,11 @@ func (s *Server) authCreateSession(ctx context.Context, action *types.AuthCreate
 
 	if len(positions) == 0 {
 		return writeText(http.StatusForbidden, "You are not a staff member [no positions]"), nil
+	}
+
+	// A bot holds no staff permissions, so it has nothing to log in to.
+	if isBot {
+		return writeText(http.StatusForbidden, "You are not a staff member [bot account]"), nil
 	}
 
 	tx, err := state.Pool.Begin(ctx)

--- a/arcadia/panel/ops_core.go
+++ b/arcadia/panel/ops_core.go
@@ -74,10 +74,7 @@ func (s *Server) hello(ctx context.Context, q *types.QHello) (response, error) {
 	return writeJSON(http.StatusOK, types.Hello{
 		InstanceConfig: types.InstanceConfig{
 			Description: instanceDescription(),
-			Warnings: []string{
-				"Oh, hello there. This panel is currently being rewritten, and may have some issues. If you find any issues, please contact a Lead Developer in the `Staff Center` Discord Server!",
-				"[Warning]: `panel.infinitybots.gg` will soon be unaccessible as we move our panel into the main site.",
-			},
+			Warnings: []string{},
 		},
 		AuthData:    authData,
 		StaffMember: staffMember,

--- a/arcadia/panel/ops_staff.go
+++ b/arcadia/panel/ops_staff.go
@@ -536,6 +536,13 @@ func (s *Server) editMember(ctx context.Context, callerID string, action *types.
 		return writeText(http.StatusForbidden, "Target has a lower index than the member"), nil
 	}
 
+	// Bots hold no staff permissions, so there is nothing here to edit. Writing
+	// the overrides anyway would leave a row that reads as a grant and resolves
+	// to nothing.
+	if target.User.Bot {
+		return writeText(http.StatusForbidden, perms.ErrBotAccount.Error()), nil
+	}
+
 	if err := perms.Staff.ValidateStrings(action.PermOverrides); err != nil {
 		return writeText(http.StatusBadRequest, err.Error()), nil
 	}

--- a/arcadia/tasks/staffresync.go
+++ b/arcadia/tasks/staffresync.go
@@ -51,6 +51,7 @@ func StaffResync(ctx context.Context) error {
 	type guildMember struct {
 		UserID snowflake.ID
 		Roles  []string
+		IsBot  bool
 	}
 
 	var staffResync []guildMember
@@ -62,7 +63,9 @@ func StaffResync(ctx context.Context) error {
 			roles = append(roles, roleID.String())
 		}
 
-		staffResync = append(staffResync, guildMember{UserID: member.User.ID, Roles: roles})
+		// The gateway is the authority on what an account is, so bots are
+		// recognised here rather than looked up again later.
+		staffResync = append(staffResync, guildMember{UserID: member.User.ID, Roles: roles, IsBot: member.User.Bot})
 	})
 
 	tx, err := state.Pool.Begin(ctx)
@@ -163,9 +166,23 @@ func StaffResync(ctx context.Context) error {
 		memberPosCache[member.UserID] = impls.UUIDStrings(member.Positions)
 	}
 
+	// bots are the bot accounts sitting in the staff server. They are tracked so
+	// that step 5 can say why it is removing one, rather than reporting them as
+	// having left a server they are still in.
+	bots := make(map[string]struct{})
+
 	// Step 4: reconcile each Discord staff member.
 	for _, user := range staffResync {
 		userID := user.UserID.String()
+
+		// A bot never becomes a staff member, whatever roles it has been given
+		// in the staff server. Leaving it out of the reconcile is also what
+		// takes an existing bot's staff row away: step 5 handles everyone the
+		// reconcile did not account for.
+		if user.IsBot {
+			bots[userID] = struct{}{}
+			continue
+		}
 
 		if _, skip := noAutosync[userID]; skip {
 			continue
@@ -318,13 +335,21 @@ func StaffResync(ctx context.Context) error {
 
 		oldSP := buildPermissions(posByID, oldPositions, overridePerms[userID])
 
-		description := fmt.Sprintf(
-			"Updated unaccounted staff member <@%s> as they are no longer in the staff server but have permission overrides.", userID)
+		// A bot is still in the staff server; it is being removed for being a
+		// bot, and saying it left would be wrong as well as confusing.
+		_, isBot := bots[userID]
 
-		if remove {
-			description = fmt.Sprintf(
-				"Removed unaccounted staff member <@%s> as they are no longer in the staff server.", userID)
+		verb, reason := "Removed", "they are no longer in the staff server"
+
+		if isBot {
+			reason = "bot accounts cannot hold staff permissions"
 		}
+
+		if !remove {
+			verb, reason = "Updated", reason+", but they have permission overrides"
+		}
+
+		description := fmt.Sprintf("%s unaccounted staff member <@%s> as %s.", verb, userID, reason)
 
 		announceResync(userID, discord.MessageCreate{
 			Embeds: []discord.Embed{{

--- a/exp/rewrite/flatperms.sql
+++ b/exp/rewrite/flatperms.sql
@@ -129,7 +129,6 @@ INSERT INTO perm_map (dom, old, new) VALUES
     ('staff', 'cdn#ibl@main.read_file',                'view_cdn'),
     ('staff', 'cdn.add_file',                          'manage_cdn'),
     ('staff', 'cdn.upload_chunk',                      'manage_cdn'),
-    ('staff', 'borealis.*',                            'use_borealis'),
 
     ('staff', 'developer.marker',                      'marker_developer'),
     ('staff', 'lead_developer.marker',                 'marker_lead_developer'),
@@ -321,6 +320,11 @@ SELECT 'entity', 'team_member.*', p
 --
 -- `global.view_sensitive` only ever meant something for staff. The one team
 -- member holding it is a team owner, so dropping it costs them nothing.
+--
+-- `borealis.*` gated the Borealis service, which the port removed outright
+-- (arcadia/CONFORMANCE.md D11a). Nothing in the codebase calls Borealis any
+-- more, so the permission gated nothing and is not carried over. If Borealis
+-- ever comes back it needs a declared permission of its own, not this one.
 -- ---------------------------------------------------------------------------
 CREATE TEMP TABLE retired_perm (
     dom text NOT NULL,
@@ -329,7 +333,8 @@ CREATE TEMP TABLE retired_perm (
 ) ON COMMIT DROP;
 
 INSERT INTO retired_perm (dom, old) VALUES
-    ('entity', 'global.view_sensitive');
+    ('entity', 'global.view_sensitive'),
+    ('staff', 'borealis.*');
 
 -- ---------------------------------------------------------------------------
 -- The translation itself.

--- a/exp/rewrite/remove_borealis_perm.sql
+++ b/exp/rewrite/remove_borealis_perm.sql
@@ -1,0 +1,116 @@
+-- Strip the retired Borealis permission from every stored permission list.
+--
+-- `use_borealis` (and the pre-migration `borealis.*` it came from) gated the
+-- Borealis service, which the port removed outright — see
+-- arcadia/CONFORMANCE.md D11a. Nothing calls Borealis any more, so the
+-- permission has gated nothing since; the catalogue no longer declares it.
+--
+-- This is needed because the permission model deliberately KEEPS names it does
+-- not declare: an undeclared permission may belong to another service, so
+-- `perms.Set` carries it through a read and a write rather than dropping it (see
+-- Set.Undeclared). Left alone, `use_borealis` would sit in these columns for
+-- good and show up under "Other services" in the staff bot and the panel.
+--
+--   USAGE
+--     psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f exp/rewrite/remove_borealis_perm.sql
+--
+--   ON_ERROR_STOP=1 matters: without it psql keeps going after a failed
+--   statement and would COMMIT a half-applied change.
+--
+-- Runs in one transaction and is idempotent: a second run reports zero rows.
+-- Only staff-domain columns are touched — Borealis was never an entity
+-- permission, so team_members.flags and api_sessions.perm_limits are left alone.
+--
+-- Losing this permission costs nobody anything: there is no Borealis to use.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+CREATE TEMP TABLE borealis_before (
+    source text NOT NULL,
+    owner  text NOT NULL,
+    perms  text[] NOT NULL
+) ON COMMIT DROP;
+
+-- Record what is about to change, so the report below is exact rather than an
+-- estimate and there is something to read back if a row looks wrong afterwards.
+INSERT INTO borealis_before (source, owner, perms)
+SELECT 'staff_positions.perms', name, perms
+  FROM staff_positions
+ WHERE perms && ARRAY['use_borealis', 'borealis.*']
+UNION ALL
+SELECT 'staff_members.perm_overrides', user_id, perm_overrides
+  FROM staff_members
+ WHERE perm_overrides && ARRAY['use_borealis', 'borealis.*']
+UNION ALL
+SELECT 'staff_disciplinary_types.perm_limits', id::text, perm_limits
+  FROM staff_disciplinary_types
+ WHERE perm_limits && ARRAY['use_borealis', 'borealis.*'];
+
+\echo ''
+\echo '=== BEFORE: rows holding the Borealis permission ==='
+
+SELECT source, owner, perms FROM borealis_before ORDER BY source, owner;
+
+-- array_remove drops every occurrence and leaves an empty array rather than
+-- NULL, which is what these columns expect.
+UPDATE staff_positions
+   SET perms = array_remove(array_remove(perms, 'use_borealis'), 'borealis.*')
+ WHERE perms && ARRAY['use_borealis', 'borealis.*'];
+
+UPDATE staff_members
+   SET perm_overrides = array_remove(array_remove(perm_overrides, 'use_borealis'), 'borealis.*')
+ WHERE perm_overrides && ARRAY['use_borealis', 'borealis.*'];
+
+UPDATE staff_disciplinary_types
+   SET perm_limits = array_remove(array_remove(perm_limits, 'use_borealis'), 'borealis.*')
+ WHERE perm_limits && ARRAY['use_borealis', 'borealis.*'];
+
+-- Verify before committing: any survivor aborts the transaction and leaves the
+-- database exactly as it was.
+DO $$
+DECLARE
+    remaining INT;
+BEGIN
+    SELECT
+        (SELECT COUNT(*) FROM staff_positions WHERE perms && ARRAY['use_borealis', 'borealis.*'])
+      + (SELECT COUNT(*) FROM staff_members WHERE perm_overrides && ARRAY['use_borealis', 'borealis.*'])
+      + (SELECT COUNT(*) FROM staff_disciplinary_types WHERE perm_limits && ARRAY['use_borealis', 'borealis.*'])
+    INTO remaining;
+
+    IF remaining <> 0 THEN
+        RAISE EXCEPTION 'Borealis permission still present in % row(s)', remaining;
+    END IF;
+
+    RAISE NOTICE 'Borealis permission removed from % row(s)', (SELECT COUNT(*) FROM borealis_before);
+END
+$$;
+
+COMMIT;
+
+\echo ''
+\echo 'Done. Nothing else changed; every other permission on those rows is untouched.'
+
+-- =====================================================================
+-- ROLLBACK
+--
+-- Only meaningful in the same session as the run above, while the temp table
+-- still exists. Otherwise put the values back from the BEFORE output by hand.
+--
+-- BEGIN;
+--
+-- UPDATE staff_positions p SET perms = b.perms
+--   FROM borealis_before b
+--  WHERE b.source = 'staff_positions.perms' AND b.owner = p.name;
+--
+-- UPDATE staff_members m SET perm_overrides = b.perms
+--   FROM borealis_before b
+--  WHERE b.source = 'staff_members.perm_overrides' AND b.owner = m.user_id;
+--
+-- UPDATE staff_disciplinary_types d SET perm_limits = b.perms
+--   FROM borealis_before b
+--  WHERE b.source = 'staff_disciplinary_types.perm_limits' AND b.owner = d.id::text;
+--
+-- COMMIT;
+-- =====================================================================

--- a/perms/bot_test.go
+++ b/perms/bot_test.go
@@ -1,0 +1,94 @@
+package perms
+
+import (
+	"testing"
+
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// A bot holds nothing, from any source, in any combination. This is the whole
+// rule, so it is tested source by source rather than once.
+func TestBotAccountHoldsNothing(t *testing.T) {
+	roles := []Role{{ID: "admins", Index: 1, Perms: []Perm{StaffAdministrator}}}
+
+	cases := []struct {
+		name   string
+		grants StaffGrants
+	}{
+		{"roles", StaffGrants{Roles: roles, BotAccount: true}},
+		{"direct grants", StaffGrants{Extras: []Perm{StaffReviewBots, StaffViewPanel}, BotAccount: true}},
+		{"the owners list", StaffGrants{ConfigOwner: true, BotAccount: true}},
+		{"everything at once", StaffGrants{
+			Roles:       roles,
+			Extras:      []Perm{StaffReviewBots},
+			ConfigOwner: true,
+			BotAccount:  true,
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolved := tc.grants.Resolve()
+
+			if !resolved.IsEmpty() {
+				t.Errorf("a bot resolved to %v", resolved.Strings())
+			}
+
+			if resolved.IsSuper() {
+				t.Error("a bot must never read as super")
+			}
+
+			for _, p := range []Perm{StaffAdministrator, StaffReviewBots, StaffViewPanel, StaffViewStaff} {
+				if resolved.Has(p) {
+					t.Errorf("a bot should not hold %s", p)
+				}
+			}
+		})
+	}
+}
+
+// Rank is what the "can I edit them" checks compare against, so a bot must not
+// inherit the standing its roles or the owners list would otherwise give it.
+func TestBotAccountHasNoRank(t *testing.T) {
+	withOwners(t, snowflake.ID(510065483693817867))
+
+	bot := StaffGrants{
+		Roles:       []Role{{ID: "admins", Index: 1, Perms: []Perm{StaffAdministrator}}},
+		ConfigOwner: true,
+		BotAccount:  true,
+	}
+
+	if got := bot.Rank(); got != NoRank {
+		t.Errorf("Rank() = %d, want NoRank (%d)", got, NoRank)
+	}
+
+	// The same grants on a person keep the standing the bot was denied, so the
+	// test is about the flag and not about the grants being empty.
+	person := bot
+	person.BotAccount = false
+
+	if got := person.Rank(); got != OwnerRank {
+		t.Errorf("a person with these grants should rank %d, got %d", OwnerRank, got)
+	}
+}
+
+// A permission cannot be handed to a bot by way of a patch check either: with
+// nothing resolved, there is nothing it is allowed to keep.
+func TestBotAccountCannotBePatchedInto(t *testing.T) {
+	bot := StaffGrants{BotAccount: true, Extras: []Perm{StaffReviewBots}}
+
+	current := bot.Resolve()
+	next := current.With(StaffReviewBots)
+
+	// The manager holds the permission, so the patch itself is legitimate; what
+	// makes it meaningless is that the bot's resolved set stays empty.
+	manager := Staff.NewSet(StaffAdministrator)
+
+	if err := CheckPatch(manager, current, next); err != nil {
+		t.Fatalf("the patch should be legitimate for the manager: %v", err)
+	}
+
+	if !bot.Resolve().IsEmpty() {
+		t.Error("writing a grant onto a bot must not resolve into anything")
+	}
+}

--- a/perms/migration_test.go
+++ b/perms/migration_test.go
@@ -34,6 +34,20 @@ func readMigration(t *testing.T) string {
 	return string(b)
 }
 
+// retired reports whether the migration drops a permission on purpose, i.e.
+// lists it in retired_perm as a ('domain', 'name') pair rather than mapping it.
+func retired(sql, domain, perm string) bool {
+	body := sql
+
+	if _, after, ok := strings.Cut(sql, "INSERT INTO retired_perm"); ok {
+		body, _, _ = strings.Cut(after, ";")
+	} else {
+		return false
+	}
+
+	return strings.Contains(body, "('"+domain+"', '"+perm+"')")
+}
+
 func catalogueFor(domain string) *Catalogue {
 	if domain == "staff" {
 		return Staff
@@ -123,6 +137,12 @@ func TestMigrationCoversTheOldVocabulary(t *testing.T) {
 			}
 		}
 
+		// Retiring a permission is handling it: the migration drops it on
+		// purpose rather than leaving it to the unmapped NOTICE.
+		if retired(sql, domain, perm) {
+			return true
+		}
+
 		// Wildcards listed together in one unnest, e.g. shop_items.* and
 		// friends, appear as quoted names in the wildcard section.
 		return strings.Contains(sql, "'"+perm+"'")
@@ -169,5 +189,32 @@ func TestMigrationCoversTheOldVocabulary(t *testing.T) {
 		if !handled("entity", perm) {
 			t.Errorf("entity permission %q was in use but the migration does not handle it", perm)
 		}
+	}
+}
+
+// Borealis was removed from the platform in the port, so its permission gated
+// nothing. It must be gone from the catalogue and dropped by the migration
+// rather than mapped onto something else.
+func TestBorealisIsRetired(t *testing.T) {
+	for _, d := range Staff.Definitions() {
+		if strings.Contains(strings.ToLower(string(d.ID)), "boreal") {
+			t.Errorf("the staff catalogue still declares %q", d.ID)
+		}
+
+		for _, old := range d.Legacy {
+			if strings.Contains(strings.ToLower(old), "boreal") {
+				t.Errorf("%q still claims to replace %q", d.ID, old)
+			}
+		}
+	}
+
+	sql := readMigration(t)
+
+	if !retired(sql, "staff", "borealis.*") {
+		t.Error("the migration should list borealis.* as retired")
+	}
+
+	if strings.Contains(sql, "use_borealis") {
+		t.Error("the migration still writes use_borealis into the database")
 	}
 }

--- a/perms/perms.go
+++ b/perms/perms.go
@@ -19,6 +19,10 @@
 // subtracts. That is the whole model, and it is why a permission check is a
 // single map lookup.
 //
+// The one exception is who may hold staff permissions at all: a Discord bot
+// account holds none, from any source, including the owners list. See
+// [ErrBotAccount].
+//
 // # Catalogues
 //
 // Every permission is declared in a [Catalogue]: [Staff] for what staff can do

--- a/perms/staff.go
+++ b/perms/staff.go
@@ -8,19 +8,27 @@ import (
 
 	"popplio/state"
 
+	"github.com/infinitybotlist/eureka/dovewing"
 	"github.com/jackc/pgx/v5"
 )
 
 // staffQuery loads a staff member's extra permissions and every role they hold
 // in one round trip, ordered by rank so the most senior role comes first.
+//
+// The join onto dovewing's user cache is the read side of [ErrBotAccount]: it
+// costs nothing here and does not need Discord to be reachable, so a bot account
+// resolves to no permissions even while the write paths that should have stopped
+// it are unavailable.
 const staffQuery = `SELECT
 	sm.perm_overrides,
 	COALESCE((
 		SELECT json_agg(json_build_object('id', sp.id::text, 'name', sp.name, 'index', sp.index, 'perms', sp.perms) ORDER BY sp.index)
 		FROM staff_positions sp
 		WHERE sp.id = ANY(sm.positions)
-	), '[]'::json)
+	), '[]'::json),
+	COALESCE(iuc.bot, false)
 FROM staff_members sm
+LEFT JOIN internal_user_cache__discord iuc ON iuc.id = sm.user_id
 WHERE sm.user_id = $1`
 
 // StaffGrants is where a staff member's permissions come from: the roles they
@@ -33,10 +41,20 @@ type StaffGrants struct {
 	// ConfigOwner marks an instance owner from the config. See [IsConfigOwner]:
 	// they hold everything and outrank everyone, whatever the database says.
 	ConfigOwner bool `json:"config_owner"`
+
+	// BotAccount marks a Discord bot account. A bot holds no staff permissions
+	// whatever the database says — see [ErrBotAccount].
+	BotAccount bool `json:"bot_account"`
 }
 
 // Resolve is every permission the member has.
 func (g StaffGrants) Resolve() Set {
+	// A bot resolves to nothing before anything else is considered, including
+	// the owners list: a bot named there is a misconfiguration, not a grant.
+	if g.BotAccount {
+		return Staff.NewSet()
+	}
+
 	set := Staff.Resolve(g.Roles, g.Extras...)
 
 	if g.ConfigOwner {
@@ -68,6 +86,11 @@ func (g StaffGrants) TopRole() (Role, bool) {
 // being more senior. A member with no roles ranks below everyone; an instance
 // owner outranks everyone.
 func (g StaffGrants) Rank() int32 {
+	// A bot holds no permissions, so it has no standing to outrank anyone.
+	if g.BotAccount {
+		return NoRank
+	}
+
 	if g.ConfigOwner {
 		return OwnerRank
 	}
@@ -104,17 +127,19 @@ func LoadStaff(ctx context.Context, userID string) (StaffGrants, error) {
 	var (
 		extras []string
 		roles  []byte
+		bot    bool
 	)
 
 	owner := IsConfigOwner(userID)
 
-	err := state.Pool.QueryRow(ctx, staffQuery, userID).Scan(&extras, &roles)
+	err := state.Pool.QueryRow(ctx, staffQuery, userID).Scan(&extras, &roles, &bot)
 
 	if err != nil {
 		// An owner is an owner before the resync has ever run, so a missing row
-		// is not an obstacle for them.
+		// is not an obstacle for them. Being a bot still is, so that branch pays
+		// for the one lookup the main query would have done for it.
 		if owner && errors.Is(err, pgx.ErrNoRows) {
-			return StaffGrants{ConfigOwner: true}, nil
+			return StaffGrants{ConfigOwner: true, BotAccount: cachedBotFlag(ctx, userID)}, nil
 		}
 
 		return StaffGrants{}, fmt.Errorf("error while getting staff perms of user %s: %w", userID, err)
@@ -130,6 +155,7 @@ func LoadStaff(ctx context.Context, userID string) (StaffGrants, error) {
 		Roles:       make([]Role, 0, len(rows)),
 		Extras:      ParseStrings(extras),
 		ConfigOwner: owner,
+		BotAccount:  bot,
 	}
 
 	for _, row := range rows {
@@ -156,4 +182,59 @@ func StaffPerms(ctx context.Context, userID string) (Set, error) {
 	}
 
 	return g.Resolve(), nil
+}
+
+// cachedBotFlag reads what dovewing's user cache already knows about an account,
+// without going to Discord for it.
+//
+// An account nobody has cached yet reads as "not a bot", which is the same
+// answer the join in [staffQuery] gives. That is not the guarantee — the write
+// paths and [RejectBotAccount] are — it is the cheap check that holds the line
+// on every permission read.
+func cachedBotFlag(ctx context.Context, userID string) bool {
+	var bot bool
+
+	err := state.Pool.QueryRow(ctx, "SELECT bot FROM internal_user_cache__discord WHERE id = $1", userID).Scan(&bot)
+
+	if err != nil {
+		return false
+	}
+
+	return bot
+}
+
+// ErrBotAccount is a bot account being offered staff permissions. Bots hold no
+// staff permissions at all: not through a role, not through a direct grant, not
+// through the owners list.
+//
+// A bot is a program with a token that other programs can be given, and the
+// staff model is built on a person being accountable for what their permissions
+// did. Nothing in the platform needs a bot to be staff either — the staff bot
+// and the panel act under a staff member's identity, never their own.
+var ErrBotAccount = errors.New("bot accounts cannot hold staff permissions")
+
+// RejectBotAccount fails with [ErrBotAccount] if a user is a Discord bot.
+//
+// This is the write side of the rule, for the paths that hand out permissions,
+// and it is deliberately the expensive check: it resolves through dovewing
+// (Redis, then the user cache table, then Discord itself), so a bot that has
+// never been seen before is still recognised. A lookup that cannot be resolved
+// fails closed, since being unable to tell what an account is is not a reason to
+// give it staff permissions.
+//
+// The read paths do not call this. They rely on the cached flag [LoadStaff]
+// already carries, so permission checks stay one query and keep working while
+// Discord does not.
+func RejectBotAccount(ctx context.Context, userID string) error {
+	user, err := dovewing.GetUser(ctx, userID, state.DovewingPlatformDiscord)
+
+	if err != nil {
+		return fmt.Errorf("could not check whether %s is a bot: %w", userID, err)
+	}
+
+	if user.Bot {
+		return ErrBotAccount
+	}
+
+	return nil
 }

--- a/perms/staff_catalogue.go
+++ b/perms/staff_catalogue.go
@@ -46,7 +46,6 @@ const (
 
 	StaffViewCDN   Perm = "view_cdn"
 	StaffManageCDN Perm = "manage_cdn"
-	StaffUseBoreal Perm = "use_borealis"
 
 	// The marker permissions carry no power inside Popplio. They label a staff
 	// member for other Infinity List services and for role display.
@@ -287,14 +286,6 @@ var Staff = NewCatalogue("staff", StaffAdministrator, []Definition{
 		Dangerous:   true,
 		Legacy:      []string{"cdn.add_file", "cdn.upload_chunk"},
 	},
-	{
-		ID:          StaffUseBoreal,
-		Name:        "Use Borealis",
-		Description: "Use the Borealis service.",
-		Category:    "External Services",
-		Legacy:      []string{"borealis.*"},
-	},
-
 	{
 		ID:          StaffMarkerDeveloper,
 		Name:        "Developer",


### PR DESCRIPTION
…rmission

- Introduced comprehensive tests for permission selection and role management in `permeditor_test.go` to ensure compliance with Discord's limits and proper handling of permissions.
- Added SQL script `remove_borealis_perm.sql` to safely remove the deprecated Borealis permission from the database, ensuring no residual permissions remain.
- Created `bot_test.go` to validate that bot accounts do not hold any permissions, reinforcing the permission model's integrity.