### PR TITLE
No Votes Yet Check

### DIFF
--- a/infernoplex/bot/leaderboard.go
+++ b/infernoplex/bot/leaderboard.go
@@ -79,6 +79,15 @@ func cmdLeaderboard() *Command {
 				return err
 			}
 
+			if len(leaderboard) == 0 {
+				return c.Send(discord.MessageCreate{
+					Embeds: []discord.Embed{{
+						Title:       "No Votes Yet",
+						Description: "Unfortuently, your server has no votes at this time.",
+					}},
+				})
+			}
+
 			var sb strings.Builder
 
 			page := 1


### PR DESCRIPTION
Instead of the Infernoplex erroring when there is no votes on a server return a simple embed stating that there is no votes currently in the database. 

Before: 
<img width="377" height="110" alt="image" src="https://github.com/user-attachments/assets/7bca1ede-c6b5-461f-bc0e-63d77e283679" />

After:
<img width="431" height="142" alt="image" src="https://github.com/user-attachments/assets/2899b0c6-cf83-413a-a246-b7941be35668" />

<!-- gk-ai-analysis-start:4d2c0cdf1ac38ab686769a0e7814e584bc65e169 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUHJldmVudHMgdGhlIGJvdCBmcm9tIGVycm9yaW5nIG9uIGVtcHR5IGxlYWRlcmJvYXJkcyBieSByZXR1cm5pbmcgYSB1c2VyLWZyaWVuZGx5IGVtYmVkIHdoZW4gdGhlcmUgYXJlIG5vIHZvdGVzLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IkVtcHR5IGxlYWRlcmJvYXJkIGNoZWNrIGFkZGVkIiwiZGVzY3JpcHRpb24iOiJBZGRlZCBsb2dpYyB0byBjaGVjayBpZiB0aGUgYGxlYWRlcmJvYXJkYCBhcnJheSBpcyBlbXB0eSwgcmV0dXJuaW5nIGFuIGVtYmVkIG1lc3NhZ2UgaW5zdGVhZCBvZiBjb250aW51aW5nIGFuZCBwb3RlbnRpYWxseSBlcnJvcmluZyBvdXQuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6ImluZmVybm9wbGV4L2JvdC9sZWFkZXJib2FyZC5nbyIsImxpbmVTdGFydCI6ODJ9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOlt7InRpdGxlIjoiVHlwbyBpbiBlbWJlZCBkZXNjcmlwdGlvbiIsImRlc2NyaXB0aW9uIjoiVGhlIHdvcmQgJ1VuZm9ydHVlbnRseScgaXMgbWlzc3BlbGxlZC4gSXQgc2hvdWxkIGJlICdVbmZvcnR1bmF0ZWx5Jy4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoiaW5mZXJub3BsZXgvYm90L2xlYWRlcmJvYXJkLmdvIiwibGluZVN0YXJ0Ijo4Nn1dLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:4d2c0cdf1ac38ab686769a0e7814e584bc65e169 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/PlexiOSS/Popplio/pull/44?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->