### PR TITLE
feat(add): staff list endpoint

### DIFF
--- a/routes/staff/endpoints/get_public_team/route.go
+++ b/routes/staff/endpoints/get_public_team/route.go
@@ -1,0 +1,124 @@
+package get_public_team
+
+import (
+	"net/http"
+	"sort"
+
+	"popplio/api/resp"
+	"popplio/state"
+	"popplio/types"
+
+	docs "github.com/infinitybotlist/eureka/doclib"
+	"github.com/infinitybotlist/eureka/dovewing"
+	"github.com/infinitybotlist/eureka/uapi"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"go.uber.org/zap"
+)
+
+func Docs() *docs.Doc {
+	return &docs.Doc{
+		Summary:     "Get Public Team",
+		Description: "Returns the public staff roster: who's on staff and what position(s) they hold.",
+		Resp:        []types.PublicStaffMember{},
+	}
+}
+
+type staffMemberRow struct {
+	UserID    string        `db:"user_id"`
+	Positions []pgtype.UUID `db:"positions"`
+}
+
+type staffPositionRow struct {
+	ID    pgtype.UUID `db:"id"`
+	Name  string      `db:"name"`
+	Icon  string      `db:"icon"`
+	Index int32       `db:"index"`
+}
+
+func Route(d uapi.RouteData, r *http.Request) uapi.HttpResponse {
+	memberRows, err := state.Pool.Query(d.Context, "SELECT user_id, positions FROM staff_members")
+
+	if err != nil {
+		return resp.Err("Error while fetching staff members [db fetch]", err)
+	}
+
+	members, err := pgx.CollectRows(memberRows, pgx.RowToStructByName[staffMemberRow])
+
+	if err != nil {
+		return resp.Err("Error while fetching staff members [collect]", err)
+	}
+
+	positionRows, err := state.Pool.Query(d.Context, "SELECT id, name, icon, index FROM staff_positions")
+
+	if err != nil {
+		return resp.Err("Error while fetching staff positions [db fetch]", err)
+	}
+
+	positionList, err := pgx.CollectRows(positionRows, pgx.RowToStructByName[staffPositionRow])
+
+	if err != nil {
+		return resp.Err("Error while fetching staff positions [collect]", err)
+	}
+
+	positionsByID := make(map[pgtype.UUID]staffPositionRow, len(positionList))
+	for _, p := range positionList {
+		positionsByID[p.ID] = p
+	}
+
+	team := make([]types.PublicStaffMember, 0, len(members))
+
+	for _, member := range members {
+		user, err := dovewing.GetUser(d.Context, member.UserID, state.DovewingPlatformDiscord)
+
+		if err != nil {
+			state.Logger.Warn("Failed to resolve staff member for public team roster", zap.Error(err), zap.String("userID", member.UserID))
+			continue
+		}
+
+		if user.Bot {
+			continue
+		}
+
+		positions := make([]types.PublicStaffPosition, 0, len(member.Positions))
+		for _, id := range member.Positions {
+			p, ok := positionsByID[id]
+			if !ok {
+				continue
+			}
+			positions = append(positions, types.PublicStaffPosition{
+				Name:  p.Name,
+				Icon:  p.Icon,
+				Index: p.Index,
+			})
+		}
+
+		sort.Slice(positions, func(i, j int) bool { return positions[i].Index < positions[j].Index })
+
+		team = append(team, types.PublicStaffMember{
+			UserID:      member.UserID,
+			Username:    user.Username,
+			DisplayName: user.DisplayName,
+			Avatar:      user.Avatar,
+			Positions:   positions,
+		})
+	}
+
+	sort.Slice(team, func(i, j int) bool {
+		iRank, jRank := int32(1<<31-1), int32(1<<31-1)
+		if len(team[i].Positions) > 0 {
+			iRank = team[i].Positions[0].Index
+		}
+		if len(team[j].Positions) > 0 {
+			jRank = team[j].Positions[0].Index
+		}
+		if iRank != jRank {
+			return iRank < jRank
+		}
+		return team[i].Username < team[j].Username
+	})
+
+	return uapi.HttpResponse{
+		Json: team,
+	}
+}

--- a/routes/staff/router.go
+++ b/routes/staff/router.go
@@ -6,6 +6,7 @@ package staff
 
 import (
 	"popplio/routes/staff/endpoints/get_app_list"
+	"popplio/routes/staff/endpoints/get_public_team"
 	"popplio/routes/staff/endpoints/get_shop_purchases"
 	"popplio/routes/staff/endpoints/get_staff_permissions"
 	"popplio/routes/staff/endpoints/manage_app"
@@ -55,5 +56,13 @@ func (b Router) Routes(r *chi.Mux) {
 		Method:  uapi.PATCH,
 		Docs:    manage_app.Docs,
 		Handler: manage_app.Route,
+	}.Route(r)
+
+	uapi.Route{
+		Pattern: "/staff/team",
+		OpId:    "get_public_team",
+		Method:  uapi.GET,
+		Docs:    get_public_team.Docs,
+		Handler: get_public_team.Route,
 	}.Route(r)
 }

--- a/types/staffteam.go
+++ b/types/staffteam.go
@@ -1,0 +1,21 @@
+package types
+
+// PublicStaffPosition is the public-safe projection of a staff position —
+// name and rank only, never the permission grants attached to it.
+type PublicStaffPosition struct {
+	Name  string `json:"name" description:"The position's name"`
+	Icon  string `json:"icon" description:"The position's icon URL, if any"`
+	Index int32  `json:"index" description:"Where this position ranks — lower is more senior"`
+}
+
+// PublicStaffMember is the public-safe projection of a staff member for the
+// team page. Unlike arcadia/types.StaffMember (the staff-panel shape), this
+// deliberately excludes permissions, disciplinaries, and sync/security
+// metadata — none of which is anyone's business but staff's.
+type PublicStaffMember struct {
+	UserID      string                `json:"user_id" description:"The staff member's user ID"`
+	Username    string                `json:"username" description:"The staff member's username"`
+	DisplayName string                `json:"display_name" description:"The staff member's display name"`
+	Avatar      string                `json:"avatar" description:"The staff member's avatar URL"`
+	Positions   []PublicStaffPosition `json:"positions" description:"Every position this member holds, most senior first"`
+}


### PR DESCRIPTION
- Added a new endpoint for listing all of our staff members with rank etc.
- This can be used by the websites upcoming `/about/team` page.